### PR TITLE
Fix Broken LDAP Wiki Link in HTTP Headers and Cookies/README.md

### DIFF
--- a/HTTP Headers and Cookies/README.md
+++ b/HTTP Headers and Cookies/README.md
@@ -180,7 +180,7 @@ Kökenler arası kaynak paylaşımı (CORS), bir web sitesi üzerindeki bazı ka
 
 **Kullanımı**
 - **pin-sha256:**
-Base64 olarak kodlanmış [SPKI](https://ldapwiki.com/wiki/Subject%20Public%20Key%20Info) parmak izidir.
+Base64 olarak kodlanmış [SPKI](https://ldapwiki.com/wiki/Wiki.jsp?page=Subject%20Public%20Key%20Info) parmak izidir.
 - **max-age:**
 Anahtarın tarayıcı hafızasında tutulacağı süreyi saniye olarak belirtir.
 - **includeSubDomains:**


### PR DESCRIPTION
Hello,

With this PR, I have updated the broken link to the LDAP Wiki page in the HTTP Headers and Cookies/README.md file. 

Changes Made
✅ Updated Broken Link in HTTP Headers and Cookies/README.md:
🔗 Old: https://ldapwiki.com/wiki/Subject%20Public%20Key%20Info (Broken)
🔗 New: https://ldapwiki.com/wiki/Wiki.jsp?page=Subject%20Public%20Key%20Info (Corrected)

This is a great repository! If you have any other content that needs improvement, feel free to leave a comment, and I'd be happy to help. 😊

Best regards